### PR TITLE
Update Docker Image to Kotlin 1.4.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,9 @@ RUN wget -nv https://download-cf.jetbrains.com/idea/${INTELLIJ_IDE_TAR} && \
     unzip android-tools.zip && \
     rm android-tools.zip && \
     yes | tools/bin/sdkmanager --licenses --sdk_root=/opt/android-sdk && \
-    tools/bin/sdkmanager --sdk_root=/opt/android-sdk "platform-tools" "platforms;android-29"
+    tools/bin/sdkmanager --sdk_root=/opt/android-sdk "platform-tools" "platforms;android-29" && \
+	wget https://plugins.jetbrains.com/files/6954/96651/kotlin-plugin-1.4.10-release-Studio4.2-1.zip && \
+    unzip kotlin-plugin-1.4.10-release-Studio4.2-1.zip && \
+    rm -rf /opt/idea/plugins/Kotlin && \
+    mv Kotlin /opt/idea/plugins/ && \
+    rm kotlin-plugin-1.4.10-release-Studio4.2-1.zip


### PR DESCRIPTION
Latest version of Intellij doesn't have Kotlin 1.4.10, so need to update it separately.